### PR TITLE
Change log level of several logging events

### DIFF
--- a/metrics/src/main/java/com/google/monitoring/metrics/MetricExporter.java
+++ b/metrics/src/main/java/com/google/monitoring/metrics/MetricExporter.java
@@ -54,9 +54,9 @@ class MetricExporter extends AbstractExecutionThreadService {
     logger.info("Started up MetricExporter");
     while (isRunning()) {
       Optional<ImmutableList<MetricPoint<?>>> batch = writeQueue.take();
-      logger.info("Got a batch of points from the writeQueue");
+      logger.fine("Got a batch of points from the writeQueue");
       if (batch.isPresent()) {
-        logger.info("Batch contains data, writing to MetricWriter");
+        logger.fine("Batch contains data, writing to MetricWriter");
         try {
           for (MetricPoint<?> point : batch.get()) {
             writer.write(point);

--- a/metrics/src/main/java/com/google/monitoring/metrics/MetricReporter.java
+++ b/metrics/src/main/java/com/google/monitoring/metrics/MetricReporter.java
@@ -84,7 +84,7 @@ public class MetricReporter extends AbstractScheduledService {
 
   @Override
   protected void runOneIteration() {
-    logger.info("Running background metric push");
+    logger.fine("Running background metric push");
 
     if (metricExporter.state() == State.FAILED) {
       startMetricExporter();

--- a/stackdriver/src/main/java/com/google/monitoring/metrics/stackdriver/StackdriverWriter.java
+++ b/stackdriver/src/main/java/com/google/monitoring/metrics/stackdriver/StackdriverWriter.java
@@ -214,7 +214,7 @@ public class StackdriverWriter implements MetricWriter {
     for (TimeSeries timeSeries : timeSeriesList) {
       pushedPoints.increment(timeSeries.getMetricKind(), timeSeries.getValueType());
     }
-    logger.info(String.format("Flushed %d metrics to Stackdriver", timeSeriesList.size()));
+    logger.fine(String.format("Flushed %d metrics to Stackdriver", timeSeriesList.size()));
   }
 
   /**


### PR DESCRIPTION
These logging events are recurring. As a result logging at INFO level
spams the user of the metrics library with periodic logs. Changing them
to FINE level so that the user can eaisily filter these logs out.