### PR TITLE
Instead of calling Subject.actual(), store the actual value in a field, and read that.

### DIFF
--- a/contrib/pom.xml
+++ b/contrib/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.37</version>
+      <version>0.44</version>
     </dependency>
     <!-- Metrics library -->
     <dependency>
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>com.google.truth.extensions</groupId>
       <artifactId>truth-java8-extension</artifactId>
-      <version>0.37</version>
+      <version>0.44</version>
       <scope>test</scope>
     </dependency>
     <!-- JUnit backport -->

--- a/contrib/src/main/java/com/google/monitoring/metrics/contrib/AbstractMetricSubject.java
+++ b/contrib/src/main/java/com/google/monitoring/metrics/contrib/AbstractMetricSubject.java
@@ -73,8 +73,11 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
               Joiner.on(':').join(metricPoint.labelValues()),
               getMessageRepresentation(metricPoint.value()));
 
+  private final Metric<T> actual;
+
   protected AbstractMetricSubject(FailureMetadata metadata, Metric<T> actual) {
     super(metadata, checkNotNull(actual));
+    this.actual = actual;
   }
 
   /**
@@ -84,7 +87,7 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
    */
   @Override
   public String actualCustomStringRepresentation() {
-    return actual().getMetricSchema().name();
+    return actual.getMetricSchema().name();
   }
 
   /**
@@ -102,7 +105,7 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
           Joiner.on(':').join(labels),
           "has labeled values",
           Lists.transform(
-              Ordering.<MetricPoint<T>>natural().sortedCopy(actual().getTimestampedValues()),
+              Ordering.<MetricPoint<T>>natural().sortedCopy(actual.getTimestampedValues()),
               metricPointConverter));
     }
     if (!metricPoint.value().equals(value)) {
@@ -130,7 +133,7 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
           Joiner.on(':').join(labels),
           "has labeled values",
           Lists.transform(
-              Ordering.<MetricPoint<T>>natural().sortedCopy(actual().getTimestampedValues()),
+              Ordering.<MetricPoint<T>>natural().sortedCopy(actual.getTimestampedValues()),
               metricPointConverter));
     }
     if (hasDefaultValue(metricPoint)) {
@@ -162,7 +165,7 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
    * has already been made.
    */
   public And<S> hasNoOtherValues() {
-    for (MetricPoint<T> metricPoint : actual().getTimestampedValues()) {
+    for (MetricPoint<T> metricPoint : actual.getTimestampedValues()) {
       if (!expectedNondefaultLabelTuples.contains(metricPoint.labelValues())) {
         if (!hasDefaultValue(metricPoint)) {
           failWithBadResults(
@@ -170,7 +173,7 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
               "no other nondefault values",
               "has labeled values",
               Lists.transform(
-                  Ordering.<MetricPoint<T>>natural().sortedCopy(actual().getTimestampedValues()),
+                  Ordering.<MetricPoint<T>>natural().sortedCopy(actual.getTimestampedValues()),
                   metricPointConverter));
         }
         return andChainer();
@@ -180,10 +183,10 @@ abstract class AbstractMetricSubject<T, S extends AbstractMetricSubject<T, S>>
   }
 
   private @Nullable MetricPoint<T> findMetricPointForLabels(ImmutableList<String> labels) {
-    if (actual().getMetricSchema().labels().size() != labels.size()) {
+    if (actual.getMetricSchema().labels().size() != labels.size()) {
       return null;
     }
-    for (MetricPoint<T> metricPoint : actual().getTimestampedValues()) {
+    for (MetricPoint<T> metricPoint : actual.getTimestampedValues()) {
       if (metricPoint.labelValues().equals(labels)) {
         return metricPoint;
       }

--- a/contrib/src/main/java/com/google/monitoring/metrics/contrib/DistributionMetricSubject.java
+++ b/contrib/src/main/java/com/google/monitoring/metrics/contrib/DistributionMetricSubject.java
@@ -58,8 +58,11 @@ public final class DistributionMetricSubject
     return assertAbout(DistributionMetricSubject::new).that(metric);
   }
 
+  private final Metric<Distribution> actual;
+
   private DistributionMetricSubject(FailureMetadata metadata, Metric<Distribution> actual) {
     super(metadata, actual);
+    this.actual = actual;
   }
 
   /**
@@ -111,7 +114,7 @@ public final class DistributionMetricSubject
    */
   public And<DistributionMetricSubject> hasDataSetForLabels(
       ImmutableSet<? extends Number> dataSet, String... labels) {
-    ImmutableList<MetricPoint<Distribution>> metricPoints = actual().getTimestampedValues();
+    ImmutableList<MetricPoint<Distribution>> metricPoints = actual.getTimestampedValues();
     if (metricPoints.isEmpty()) {
       failWithBadResults(
           "has a distribution for labels", Joiner.on(':').join(labels), "has", "no values");

--- a/metrics/pom.xml
+++ b/metrics/pom.xml
@@ -64,7 +64,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.37</version>
+      <version>0.44</version>
       <scope>test</scope>
     </dependency>
     <!-- JUnit backport -->

--- a/stackdriver/pom.xml
+++ b/stackdriver/pom.xml
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.truth</groupId>
       <artifactId>truth</artifactId>
-      <version>0.37</version>
+      <version>0.44</version>
       <scope>test</scope>
     </dependency>
     <!-- JUnit backport -->


### PR DESCRIPTION
actual() is being removed.

While there, upgrade to Truth 0.44. The upgade isn't necessary for the actual() migration, but it should reduce the chance that we end up using other methods that are later removed.