### PR TITLE
Fix flaky test in MetricRegistryImplTest

### DIFF
--- a/metrics/src/test/java/com/google/monitoring/metrics/MetricRegistryImplTest.java
+++ b/metrics/src/test/java/com/google/monitoring/metrics/MetricRegistryImplTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.metrics.MetricSchema.Kind;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -38,6 +39,16 @@ public class MetricRegistryImplTest {
   private final LabelDescriptor label =
       LabelDescriptor.create("test_labelname", "test_labeldescription");
 
+  /**
+   * Add {@code unregisterAllMetrics} before the class
+   * in case metrics not unregistered at the beginning
+   * and cause flaky test
+   */
+  @BeforeClass
+  public static void beforeClassClearMetrics() {
+    MetricRegistryImpl.getDefault().unregisterAllMetrics();
+  }
+  
   @After
   public void clearMetrics() {
     MetricRegistryImpl.getDefault().unregisterAllMetrics();


### PR DESCRIPTION
Fixed flaky test that caused by `MetricRegistryImpl` in `com.google.monitoring.metrics.MetricRegistryImplTest.java`.

Existing tests are flaky because the `MetricRegistryImpl` doesn't clear metrics at the beginning of this class.

The flaky tests are found by running https://github.com/idflakies/iDFlakies